### PR TITLE
Update main.yml

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Invoke autodeploy
-  command: curl --data "" localhost:81
+  command: curl -X POST localhost:81
   when: autodeploy_inital_deploy
   register: out
   notify: Invoke autodeploy | output


### PR DESCRIPTION
`-d ''` is opaque. It happens to set the HTTP method to POST by default unless otherwise specified, but `-X POST` is more obvious, and better expresses the intent of the command (setting the method to POST).