### PR TITLE
Removed ansible-ansible from autodeploy dependencies 

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,6 +32,3 @@ dependencies:
     when: autodeploy_listener == 'node'
   - role: telusdigital.php
     when: autodeploy_listener == 'php'
-  - role: telusdigital.robot-sweatshop
-    when: autodeploy_listener == 'robot_sweatshop'
-  - role: telusdigital.yo-dawg


### PR DESCRIPTION
Forge now handles the install and this dependency complicates the ansible 2.0 upgrade issue. 
Also removed the RS reference.