### PR TITLE
Harden autodeploy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,6 @@ autodeploy_deployment_on_reboot: no
 # keys
 deployment_private_key: ''
 deployment_public_key: ''
+
+autodeploy_listener_addresses:
+  - "*"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,5 +74,6 @@ autodeploy_deployment_on_reboot: no
 deployment_private_key: ''
 deployment_public_key: ''
 
+autodeploy_listener_port: 81
 autodeploy_listener_addresses:
   - "*"

--- a/templates/etc/haproxy/fragments.d/81-deployment
+++ b/templates/etc/haproxy/fragments.d/81-deployment
@@ -1,5 +1,7 @@
 frontend deployment-in
-  bind :81
+{% for address in autodeploy_listener_addresses %}
+  bind {{ address }}:{{ autodeploy_listener_port }}
+{% endfor %}
   default_backend listener
 
 backend listener

--- a/templates/etc/nginx/sites-available/deployment.conf
+++ b/templates/etc/nginx/sites-available/deployment.conf
@@ -1,7 +1,9 @@
 # {{ ansible_managed }}
 
 server {
-  listen *:81;
+{% for address in autodeploy_listener_addresses %}
+  listen {{ address }}:81;
+{% endfor %}
   server_name localhost;
 
 {% if autodeploy_listener == 'php' %}

--- a/templates/etc/nginx/sites-available/deployment.conf
+++ b/templates/etc/nginx/sites-available/deployment.conf
@@ -2,7 +2,7 @@
 
 server {
 {% for address in autodeploy_listener_addresses %}
-  listen {{ address }}:81;
+  listen {{ address }}:{{ autodeploy_listener_port }};
 {% endfor %}
   server_name localhost;
 


### PR DESCRIPTION
allows you to specify list of cidr to listen too (like github or bitbucket), have not locked it down to that extent yet but this lays out the foundation to do that.