### PR TITLE
Change the newrelic API deploy curl to v2 of api syntax

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ autodeploy_slack_channel: "{{ project }}-ops"
 # newrelic
 autodeploy_newrelic_notifications_enabled: no
 autodeploy_newrelic_application_name: none
+autodeploy_newrelic_application_id: none
 
 # dependency management
 autodeploy_compass_enabled: no

--- a/templates/data/deployment/deploy.yml
+++ b/templates/data/deployment/deploy.yml
@@ -197,7 +197,7 @@
 {% if autodeploy_newrelic_notifications_enabled and environment_tier == 'production' %}
     - name: Notify NewRelic
       uri:
-        url: https://api.newrelic.com/v2/applications/"{{ newrelic_application_id }}"/deployments.json
+        url: "https://api.newrelic.com/v2/applications/{{ autodeploy_newrelic_application_id }}/deployments.json"
         method: POST
         status_code: 201
         headers:

--- a/templates/data/deployment/deploy.yml
+++ b/templates/data/deployment/deploy.yml
@@ -197,10 +197,13 @@
 {% if autodeploy_newrelic_notifications_enabled and environment_tier == 'production' %}
     - name: Notify NewRelic
       uri:
-        url: https://api.newrelic.com/deployments.xml
+        url: https://api.newrelic.com/v2/applications/"{{ newrelic_application_id }}"/deployments.json
         method: POST
+        status_code: 201
         headers:
           x-api-key: "{{ newrelic_api_key }}"
-        body: "deployment[app_name]={{ autodeploy_newrelic_application_name }}"
-
+        body_format: json
+        body:
+          deployment:
+            revision: "auto-deploy"
 {% endif %}


### PR DESCRIPTION
The version 2 of the newrelic API recieves a different call to POST deployments.
In this version, it requires you to enter in the application_id in the url.
The revision could be a git commit instead of "auto-deploy"